### PR TITLE
Fixed level not setting on respawn.

### DIFF
--- a/src/TheClimbing/RPGLike/EventListener.php
+++ b/src/TheClimbing/RPGLike/EventListener.php
@@ -12,8 +12,8 @@
     use pocketmine\event\player\PlayerMoveEvent;
     use pocketmine\event\player\PlayerJoinEvent;
     use pocketmine\event\player\PlayerExperienceChangeEvent;
-    use pocketmine\event\player\PlayerDeathEvent;
     use pocketmine\event\player\PlayerQuitEvent;
+    use pocketmine\event\player\PlayerRespawnEvent;
 
     use TheClimbing\RPGLike\Forms\RPGForms;
     use TheClimbing\RPGLike\Players\PlayerManager;
@@ -93,7 +93,7 @@
             }
         }
         
-        public function onDeath(PlayerDeathEvent $event)
+        public function onRespawn(PlayerRespawnEvent $event)
         {
             $player = $event->getPlayer();
             if ($player instanceof RPGPlayer)


### PR DESCRIPTION
The current plugin version's level resetting system doesn't seem to work(maybe caused by different versions of PMMP?)